### PR TITLE
Add styling to 'video-container'

### DIFF
--- a/css/clean-blog.css
+++ b/css/clean-blog.css
@@ -395,3 +395,20 @@ img::-moz-selection {
 body {
   webkit-tap-highlight-color: #0085a1;
 }
+
+.video-container {
+  margin: 10px 0;
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 35px;
+  height: 0;
+  overflow: hidden;
+}
+
+.video-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
Add margin spacing around YouTube videos so they are not stacked seamlessly on top of each other. Improves the look of the video-containers on the page. 
